### PR TITLE
Only delete the report file when it exists

### DIFF
--- a/tasks/jscpd-reporter.js
+++ b/tasks/jscpd-reporter.js
@@ -112,7 +112,9 @@ module.exports = function(grunt) {
             }
 
             //cleanup report
-            fs.unlink(process.cwd() + '/' + config.options.outputDir + '/index.html');
+            var reportFile = process.cwd() + '/' + config.options.outputDir + '/index.html';
+            if (grunt.file.exists(reportFile))
+                fs.unlink(reportFile);
 
             //load templates and output xml
             loadTemplates();


### PR DESCRIPTION
When running the reporter for the first time, the report file doesn't exist yet and the unlink operation will yield an error.